### PR TITLE
Merge changes from upstream to fix "rm: cannot remove '/app': Read-only file system"

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Heroku Multi Procfile buildpack
+# Heroku Monorepo Buildpack
 
 Imagine you have a single code base, which has a few different applications within it... or at least the ability to run a few different applications. Or, maybe you're Google with your mono repo?
 

--- a/bin/compile
+++ b/bin/compile
@@ -1,4 +1,8 @@
 #!/usr/bin/env bash
+
+# Ensure wildcards in globs match dotfiles too.
+shopt -s dotglob
+
 indent() {
     sed -u 's/^/      /'
 }
@@ -16,8 +20,8 @@ APP_BASE="$(cat "${ENV_DIR}/APP_BASE")"
 
 (
     mv "${BUILD_DIR}/${APP_BASE}" "${STAGE}" &&
-    rm -rf "${BUILD_DIR}" &&
-    mv "${STAGE}/$(basename "$APP_BASE")" "${BUILD_DIR}"
+    rm -rf "${BUILD_DIR}"/* &&
+    mv "${STAGE}/$(basename "$APP_BASE")"/* "${BUILD_DIR}"
 )
 
 if [ $? -ne 0 ]; then


### PR DESCRIPTION
Hi

I'm on the team that maintains Heroku's build system and official buildpacks.

Very soon we are going to make a change to the Heroku build system that will mean builds using this buildpack fail with errors like:

```
remote: -----> Monorepo app detected
remote: rm: cannot remove '/app': Read-only file system
remote:       FAILED to copy directory into place
remote:  !     Push rejected, failed to compile Monorepo app.
```

A fix for this compatibility issue has been merged into the upstream repository from which this one is forked:
lstoll/heroku-buildpack-monorepo/pull/13

This PR merges the changes from the upstream repository (which include that fix) back to this fork, so as to avoid any disruption to your builds in the future.

If you would like to avoid the merge commit from this PR (so that the two repository's Git histories do not diverge), then I'd recommend closing this PR as unmerged, and instead pulling upstream directly into `master` of this repo.

For more information about the upcoming Heroku build system change and why this fix was needed, see:
lstoll/heroku-buildpack-monorepo/issues/12

I'm also happy to answer any questions you may have via discussion on this PR :-)